### PR TITLE
Remove webmaster, search, and partner pages

### DIFF
--- a/header.php
+++ b/header.php
@@ -63,9 +63,7 @@ echo<<<HTML
      <a href="index.php">Welcome!</a>
      <a href='http://$org_site/uslims3_newlims/request_new_instance.php'>
         Request New LIMS</a>
-     <a href="partners.php">Partners</a>
      <a href="contacts.php">Contacts</a>
-     <a href="mailto:demeler@gmail.com">Webmaster</a>
    </div>
 HTML;
 ?>

--- a/partners.php
+++ b/partners.php
@@ -1,1 +1,0 @@
-../common/partners.php

--- a/search.php
+++ b/search.php
@@ -1,1 +1,0 @@
-../common/search.php


### PR DESCRIPTION
This pull request removes links and references related to the "Partners" section and the "Webmaster" contact from the website. The changes streamline the navigation and remove unused or unnecessary files.

Navigation cleanup:

* Removed the "Partners" and "Webmaster" links from the navigation bar in `header.php`.

File removal:

* Deleted references to `../common/partners.php` in `partners.php`, effectively removing the partners page.
* Deleted references to `../common/search.php` in `search.php`, removing the search functionality or page.

search page used google api that was deactivated.